### PR TITLE
[[CHORE]] Make timeouts compatible with Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ INFO  Service stopped
 ### ServerRunner
 Starts a node server in the specified port. Features:
  - Adds listeners to the server to print its lifecycle, allowing monitorization.
- - Adds support for a graceful shutdown, with a 10s grace period.
+ - Adds support for a graceful shutdown, with a 9.5s grace period.
 
 ### MongoRunner
 Starts a mongodb client with the specified options. Features:

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "info": "npm-scripts-info",
     "lint": "tslint './src/**/*.ts'",
     "prepublish": "npm run build",
-    "start": "./example/bin/resistart",
+    "start": "./example/bin/server",
     "security": "nsp check",
     "test": "npm run build && mocha -R spec 'lib/**/*.spec.js'",
     "watch": "npm-run-all --parallel watch:*",

--- a/src/server.ts
+++ b/src/server.ts
@@ -42,7 +42,9 @@ export class ServerRunner extends Runner<Server> {
     this.server = opt.server;
     this.port = opt.port;
 
-    enableTerminate(this.server);
+    // Docker will kill the container by default in 10s
+    // Give some time to log things before exiting
+    enableTerminate(this.server, { timeout: 9500 });
   }
 
   /**


### PR DESCRIPTION
Docker sends a SIGKILL to the pid after 10 seconds if the process has not exited normally. So, we force exit just before to get some logs and predefined exit codes