### PR TITLE
[[FIX]] Use proper exit codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Each runner is a proven block that saves you from writing boilerplate and error-
 There are several runners available. More on this can be found in the [example folder](example/).
 
 Moreover, alfafa also prints traces for monitoring the startup, and manages the operating system
-signals and unhandled exceptions/rejections.
+signals and unhandled exceptions/rejections/warnings.
 
 ```sh
 node server.js


### PR DESCRIPTION
Propagate exit codes just as node does: If we receive an SIGINT, the process must exit with that exit code: 128 + 2(SIGINT) 

Added support for SIGUSR2, that is how `nodemon` manages restarts: This will avoid having lots of connections to mongodb while developing