### PR TITLE
[[FEAT]] HTTPAgentRunner

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ const config = require('./config');
 let app = express(); // use your favorite framework
 let server = http.createServer(app); // your app will be exposed as an http server
 let client = new MongoClient();
+let agent = new http.Agent({ keepAlive: true });
 
 // Create a startup way to bring up your service
 let startup = new alfalfa.Startup();
@@ -26,10 +27,11 @@ let startup = new alfalfa.Startup();
 startup.check(() => config.validate());
 
 // Configure the runners you want to use
+startup.use(new alfalfa.HTTPAgentRunner({ agent }));
 startup.use(new alfalfa.ServerRunner({ server, port: 3000 }));
 startup.use(new alfalfa.MongoRunner({ client, uri: 'mongodb://localhost:27017/alfalfa' }));
 
-startup.bootstap(); // Yeah!
+startup.bootstap('Service'); // Yeah! Create the process with title 'Service' 
 ```
 
 What's is going on here? Alfalfa bootstraps your app by starting each one of the runners defined.
@@ -65,6 +67,10 @@ Starts a node server in the specified port. Features:
 Starts a mongodb client with the specified options. Features:
  - Adds listeners to the connection to print its lifecycle, allowing monitorization.
  - Adds support for retrying the connection at runtime and at *startup time*.
+
+### HTTPAgentRunner
+Tracks a KeepAlived [http.Agent](https://nodejs.org/api/http.html#http_new_agent_options). Features:
+ - Destroys the keep alived sokets when the service shutdows
 
 ## LICENSE
 

--- a/example/lib/httpagent.js
+++ b/example/lib/httpagent.js
@@ -1,0 +1,8 @@
+'use strict';
+
+const http = require('http');
+
+/** Create a KeepAlived agent to have always connected sockets */
+var agent = new http.Agent({ keepAlive: true });
+
+module.exports = agent;

--- a/example/lib/startup.js
+++ b/example/lib/startup.js
@@ -3,11 +3,17 @@
 const alfalfa = require('alfalfa');
 const server = require('./server');
 const client = require('./mongoclient');
+const httpAgent = require('./httpagent');
 const config = require('./config');
 
 let startup = new alfalfa.Startup();
 
 startup.check(() => config.validate());
+
+startup.use(new alfalfa.HTTPAgentRunner({
+  name: 'KeepAlivedHTTPAgent',
+  agent: httpAgent
+}));
 
 startup.use(new alfalfa.ServerRunner({
   name: 'MyServer',

--- a/example/package.json
+++ b/example/package.json
@@ -10,7 +10,7 @@
   "author": "Javier Mendiara Cañardo <jmendiara@gmail.com>",
   "license": "ISC",
   "dependencies": {
-    "alfalfa": "^2.1.0",
+    "alfalfa": "^2.2.0",
     "commander": "^2.9.0",
     "convict": "^1.5.0",
     "convict-commander": "^1.0.0",

--- a/src/httpagent.ts
+++ b/src/httpagent.ts
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright 2016 Telefónica I+D
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Therror, { Classes }  from 'therror';
+
+import { Runner, logger } from './';
+import { Errors } from './errors';
+import { Agent } from 'http';
+
+export interface HTTPAgentOptions {
+  /**  */
+  name?: string;
+  /** the agent instance */
+  agent: Agent;
+}
+
+/**
+ * Agent Runner takes care of destroying HTTPAgents with KeepAlive
+ *
+ * @see https://nodejs.org/api/http.html#http_agent_destroy
+ */
+export class HTTPAgentRunner extends Runner<Agent> {
+
+  agent: Agent;
+
+  constructor(opt: HTTPAgentOptions) {
+    super(opt.name || 'HTTPAgent');
+    this.agent = opt.agent;
+  }
+
+  protected doStart(): Promise<Agent> {
+    return Promise.resolve(this.agent);
+  }
+
+  protected doStop(): Promise<Agent> {
+    this.agent.destroy();
+    return Promise.resolve(this.agent);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,4 +25,5 @@ export { Errors } from './errors';
 export { Runner } from './runner';
 export { ServerRunner } from './server';
 export { MongoRunner } from './mongo';
+export { HTTPAgentRunner } from './httpagent';
 export { Startup } from './startup';

--- a/src/mongo.ts
+++ b/src/mongo.ts
@@ -22,7 +22,6 @@ import { MongoClient, Db, MongoClientOptions } from 'mongodb';
 import * as Bluebird from 'bluebird';
 import * as retryPromise from 'bluebird-retry';
 
-
 export interface MongoRunnerOptions {
   name?: string;
   client: MongoClient;


### PR DESCRIPTION
Adds support for keepAlive http agents 
https://nodejs.org/api/http.html#http_new_agent_options

```js
startup.use(new alfalfa.HTTPAgentRunner({ 
  agent: new http.Agent({ keepAlive: true })
}));
```

Because of...
### agent.destroy()
https://nodejs.org/api/http.html#http_agent_destroy
> It is usually not necessary to do this. However, if you are using an agent with KeepAlive enabled, then it is best to explicitly shut down the agent when you know that it will no longer be used. Otherwise, sockets may hang open for quite a long time before the server terminates them.